### PR TITLE
:sparkles: Deploy non validator nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ devops/terraform/destroy/%: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy -target=module.gce_worker_container[\"$*\"].google_compute_instance.this -auto-approve
 
 # only redeploy the VM
-devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validator1 devops/terraform/destroy/customer2
+devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validator1 devops/terraform/destroy/full-node1 devops/terraform/destroy/full-node2
 	make devops/terraform/apply
 
 devops/terraform/output/google_compute_instance_ip: devops/terraform/select/$(WORKSPACE)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -16,6 +16,10 @@ write_app_toml() {
 }
 
 import_keys() {
+    # non validator would not have these variables set
+    if [[ -z "$PRIV_VALIDATOR_KEY" ]]; then
+        return
+    fi
     KEYFILE_PATH=/tmp/tendermint-keyfile.txt
     echo -e $TENDERMINT_KEYFILE > $KEYFILE_PATH
     cantod keys import main $KEYFILE_PATH <<EOF

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -3,29 +3,22 @@ resource "google_project_service" "secretmanager" {
   service  = "secretmanager.googleapis.com"
 }
 
-data "google_secret_manager_secret_version" "mnemonic" {
-  for_each   = toset(var.validator_slugs)
-  secret     = "${local.prefix}-${each.key}-mnemonic"
-  version    = "latest"
-  depends_on = [google_project_service.secretmanager]
-}
-
 data "google_secret_manager_secret_version" "tendermint_keyfile" {
-  for_each   = toset(var.validator_slugs)
+  for_each   = toset(var.validator_nodes)
   secret     = "${local.prefix}-${each.key}-tendermint-keyfile"
   version    = "latest"
   depends_on = [google_project_service.secretmanager]
 }
 
 data "google_secret_manager_secret_version" "passphrase" {
-  for_each   = toset(var.validator_slugs)
+  for_each   = toset(var.validator_nodes)
   secret     = "${local.prefix}-${each.key}-passphrase"
   version    = "latest"
   depends_on = [google_project_service.secretmanager]
 }
 
 data "google_secret_manager_secret_version" "priv_validator_key" {
-  for_each   = toset(var.validator_slugs)
+  for_each   = toset(var.validator_nodes)
   secret     = "${local.prefix}-${each.key}-priv-validator-key"
   version    = "latest"
   depends_on = [google_project_service.secretmanager]

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -12,17 +12,13 @@ environment = "dev"
 # gcloud compute machine-types list
 machine_type    = "e2-standard-4"
 prefix          = "canto"
-validator_slugs = ["validator1"]
+validator_nodes = ["validator1"]
+full_nodes      = ["full-node1", "full-node2"]
 ssh_keys = {
   "andre" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXL0+ecc//lAJhiY0YIpKjkHXA7SUv4ouw+29Gps8YYme8fzTn7/gWWO11ALqqqycoJuLn7CBzCRWrUmxn1u2XsEQyaYmfbRKAUktbevHgJtQv2l8OhAmWFhRKvuMA/J5L5jY4FoozC0iQywQWLbC4Vzh7gjwxmqS7PPbamzE6xa45aI4AsxPHN1Ac2tUuuow5ILGC4Vw2bHa/7k5dnwLTGFAIJIXAn4nullC5y4hLQMJPK7NzW+77PKXzEJEye26c98rEbqdzNBnxjz+TH0B6IMZ6GtnmjArCMJPbWfitjBc8Qf/q5X8akoPQqZpkqu/ZB/MXrhfxz400PjZ0yYK710bL+wC0oeEgjlFxfuBPCICSiJqTRVr6O4tkDG3axnqPWKQjUlXkMkQkMjjZy0oZmF1/mffdODuJ6ALicREjKAcS+yOzVcJP9ZqMFHwLhaGLYjCGy//w6q/R2uVm51qEOiWP824ESIFzOQly6Udh1Jeue5JRCaAuZv+6wP4RNO8="
 }
 create_firewall_rule = true
 vm_tags              = ["tendermint-p2p"]
-
-# Per validator override
-validator_slug_to_validator_name_map = {
-  validator1 = "validator"
-}
 
 # https://docs.canto.io/evm-development/quickstart-guide
 environment_to_chain_id = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,18 +60,16 @@ variable "vm_tags" {
   default     = []
 }
 
-variable "validator_slugs" {
-  type    = list(string)
-  default = []
+variable "full_nodes" {
+  description = "Slug of the non validator full nodes."
+  type        = list(string)
+  default     = []
 }
 
-
-# Map the validator to the instance name
-# TODO: this is more to demo validator specific setting, but in fact it just changes
-# the compute instance name. Later the compute instance name will simply be derived from
-# the slug, but validator moniker could be specifically overridden.
-variable "validator_slug_to_validator_name_map" {
-  type = map(string)
+variable "validator_nodes" {
+  description = "Slug of the nodes that will perform validation."
+  type        = list(string)
+  default     = []
 }
 
 variable "default_chain_id" {
@@ -89,4 +87,5 @@ locals {
   prefix      = "${var.prefix}-${local.environment}"
   image_name  = "canto-validator-${local.environment}"
   chain_id    = lookup(var.environment_to_chain_id, local.environment, var.default_chain_id)
+  all_nodes   = concat(var.validator_nodes, var.full_nodes)
 }


### PR DESCRIPTION
Make it possible to deploy validator and non validator nodes. Only the validator nodes require keys deployment.
Deployed 1 validator node and 2 non validator nodes.