### PR TITLE
:wrench: Introduce non validator node reverse proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,18 @@ devops/terraform/destroy/all: devops/terraform/select/$(WORKSPACE)
 devops/terraform/destroy/%: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy -target=module.gce_worker_container[\"$*\"].google_compute_instance.this -auto-approve
 
-# only redeploy the VM
-devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validator1 devops/terraform/destroy/full-node1 devops/terraform/destroy/full-node2
+devops/terraform/destroy/nodes: devops/terraform/destroy/node1 devops/terraform/destroy/node2
+
+devops/terraform/destroy/validators: devops/terraform/destroy/validator1
+
+devops/terraform/destroy/proxies: devops/terraform/select/$(WORKSPACE)
+	terraform -chdir=terraform destroy -target=google_compute_instance.reverse_proxy -auto-approve
+
+devops/terraform/redeploy/nodes: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/nodes
+	make devops/terraform/apply
+
+# redeploy the nodes & validators VM
+devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validators devops/terraform/destroy/nodes
 	make devops/terraform/apply
 
 devops/terraform/output/google_compute_instance_ip: devops/terraform/select/$(WORKSPACE)

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -1,0 +1,53 @@
+# TODO: ideally a `google_cloud_run_service` with a nginx image
+resource "google_compute_instance" "reverse_proxy" {
+  for_each     = var.create_reverse_proxy ? toset(var.full_nodes) : []
+  name         = "${local.prefix}-reverse-proxy-${each.key}-${var.environment}"
+  machine_type = "e2-micro"
+  tags         = ["web"]
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11-bullseye-v20221102"
+    }
+  }
+  network_interface {
+    network = "default"
+    access_config {
+      nat_ip = google_compute_address.static[each.key].address
+    }
+  }
+
+  metadata = {
+    ssh-keys = join("\n", [for user, key in var.ssh_keys : "${user}:${key}"])
+  }
+
+  metadata_startup_script = <<EOT
+apt update
+apt --yes install nginx
+mkdir -p /etc/letsencrypt/{archive,live}/${each.key}${var.node_domain_suffix}
+echo '${contains(var.full_nodes, each.key) ? data.google_secret_manager_secret_version.cert_fullchain[each.key].secret_data : ""}' > /etc/letsencrypt/archive/${each.key}${var.node_domain_suffix}/fullchain.pem
+echo '${contains(var.full_nodes, each.key) ? data.google_secret_manager_secret_version.cert_key[each.key].secret_data : ""}' > /etc/letsencrypt/archive/${each.key}${var.node_domain_suffix}/privkey.pem
+ln -sfn /etc/letsencrypt/archive/${each.key}${var.node_domain_suffix}/fullchain.pem /etc/letsencrypt/live/${each.key}${var.node_domain_suffix}/
+ln -sfn /etc/letsencrypt/archive/${each.key}${var.node_domain_suffix}/privkey.pem /etc/letsencrypt/live/${each.key}${var.node_domain_suffix}/
+# TODO: use terraform templating
+echo 'server {
+    listen      80 default_server;
+    listen      [::]:80 default_server;
+    listen      443 ssl http2 default_server;
+    listen      [::]:443 ssl http2 default_server;
+    ssl_certificate "/etc/letsencrypt/live/${each.key}${var.node_domain_suffix}/fullchain.pem";
+    ssl_certificate_key "/etc/letsencrypt/live/${each.key}${var.node_domain_suffix}/privkey.pem";
+    ssl_session_cache shared:SSL:1m;
+    ssl_session_timeout  10m;
+
+    proxy_redirect      off;
+    proxy_set_header    X-Real-IP $remote_addr;
+    proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header    Host $http_host;
+
+    location / {
+        proxy_pass http://${module.gce_worker_container[each.key].google_compute_instance_ip}:${var.tendermint_api_port};
+    }
+}' > /etc/nginx/sites-available/default
+systemctl restart nginx
+EOT
+}

--- a/terraform/gce-with-container/main.tf
+++ b/terraform/gce-with-container/main.tf
@@ -52,7 +52,9 @@ resource "google_compute_instance" "this" {
   network_interface {
     network = var.network_name
 
-    access_config {}
+    access_config {
+      nat_ip = google_compute_address.static.address
+    }
   }
 
   metadata = {
@@ -69,33 +71,5 @@ resource "google_compute_instance" "this" {
     scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
     ]
-  }
-}
-
-resource "google_compute_firewall" "allow_tag_tendermint_p2p" {
-  count       = var.create_firewall_rule ? 1 : 0
-  name        = "${local.prefix}${local.instance_name}-ingress-tag-p2p"
-  description = "Ingress to allow Tendermint P2P ports to machines with the 'tendermint-p2p' tag"
-  network = var.network_name
-  source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["tendermint-p2p"]
-
-  allow {
-    protocol = "tcp"
-    ports    = [var.tendermint_p2p_port]
-  }
-}
-
-resource "google_compute_firewall" "allow_tag_tendermint_rpc" {
-  count       = var.create_firewall_rule ? 1 : 0
-  name        = "${local.prefix}${local.instance_name}-ingress-tag-rpc"
-  description = "Ingress to allow Tendermint RPC ports to machines with the 'tendermint-rpc' tag"
-  network = var.network_name
-  source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["tendermint-rpc"]
-
-  allow {
-    protocol = "tcp"
-    ports    = [var.tendermint_rpc_port]
   }
 }

--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -1,0 +1,45 @@
+resource "google_compute_address" "static" {
+  name = "${local.prefix}${local.instance_name}-ipv4-address"
+}
+
+resource "google_compute_firewall" "allow_tag_tendermint_p2p" {
+  count       = var.create_firewall_rule ? 1 : 0
+  name        = "${local.prefix}${local.instance_name}-ingress-tag-p2p"
+  description = "Ingress to allow Tendermint P2P ports to machines with the 'tendermint-p2p' tag"
+  network = var.network_name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["tendermint-p2p"]
+
+  allow {
+    protocol = "tcp"
+    ports    = [var.tendermint_p2p_port]
+  }
+}
+
+resource "google_compute_firewall" "allow_tag_tendermint_rpc" {
+  count       = var.create_firewall_rule ? 1 : 0
+  name        = "${local.prefix}${local.instance_name}-ingress-tag-rpc"
+  description = "Ingress to allow Tendermint RPC ports to machines with the 'tendermint-rpc' tag"
+  network = var.network_name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["tendermint-rpc"]
+
+  allow {
+    protocol = "tcp"
+    ports    = [var.tendermint_rpc_port]
+  }
+}
+
+resource "google_compute_firewall" "allow_tag_tendermint_api" {
+  count       = var.create_firewall_rule ? 1 : 0
+  name        = "${local.prefix}${local.instance_name}-ingress-tag-api"
+  description = "Ingress to allow Tendermint API ports to machines with the 'tendermint-api' tag"
+  network = var.network_name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["tendermint-api"]
+
+  allow {
+    protocol = "tcp"
+    ports    = [var.tendermint_api_port]
+  }
+}

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -32,6 +32,12 @@ variable "tendermint_rpc_port" {
   default     = 26657
 }
 
+variable "tendermint_api_port" {
+  description = "Port for interacting with the REST API."
+  type        = number
+  default     = 1317
+}
+
 variable "instance_name" {
   description = "The desired name to assign to the deployed instance"
   default = "disk-instance-vm-test"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,16 +45,17 @@ module "gce_worker_container" {
     TENDERMINT_KEYFILE      = contains(var.validator_nodes, each.key) ? replace(data.google_secret_manager_secret_version.tendermint_keyfile[each.key].secret_data, "\n", "\\n") : ""
     PASSPHRASE              = contains(var.validator_nodes, each.key) ? data.google_secret_manager_secret_version.passphrase[each.key].secret_data : ""
     PRIV_VALIDATOR_KEY      = contains(var.validator_nodes, each.key) ? replace(data.google_secret_manager_secret_version.priv_validator_key[each.key].secret_data, "\n", "\\n") : ""
+    API                     = contains(var.full_nodes, each.key) ? "true" : "false"
+    UNSAFE_CORS             = contains(var.full_nodes, each.key) ? "true" : "false"
+    API_PORT                = var.tendermint_api_port
+    P2P_PORT                = var.tendermint_p2p_port
+    RPC_PORT                = var.tendermint_rpc_port
   }
   instance_name        = "${each.key}-${var.environment}"
   network_name         = "default"
   create_firewall_rule = var.create_firewall_rule
-  vm_tags              = var.vm_tags
+  vm_tags              = contains(var.validator_nodes, each.key) ? var.validators_vm_tags : var.nodes_vm_tags
   # This has the permission to download images from Container Registry
   client_email = var.client_email
   ssh_keys     = var.ssh_keys
-}
-
-output "google_compute_instance_ip" {
-  value = values(module.gce_worker_container).*.google_compute_instance_ip
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,17 @@
+resource "google_compute_address" "static" {
+  for_each = toset(var.full_nodes)
+  name     = "${local.prefix}-ipv4-address-${each.key}-${var.environment}"
+}
+
+resource "google_compute_firewall" "web" {
+  name          = "${local.prefix}-firewall-tag-web-${var.environment}"
+  description   = "Ingress to allow Tendermint ports 80 and 443 to machines with the 'web' tag"
+  network       = "default"
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["web"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "google_compute_instance_ip" {
+  value = values(module.gce_worker_container).*.google_compute_instance_ip
+}

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -23,3 +23,18 @@ data "google_secret_manager_secret_version" "priv_validator_key" {
   version    = "latest"
   depends_on = [google_project_service.secretmanager]
 }
+
+# certificates are consumed by the reverse proxy to expose the REST API over SSL
+data "google_secret_manager_secret_version" "cert_fullchain" {
+  for_each   = toset(var.full_nodes)
+  secret     = "${local.prefix}-${each.key}-cert-fullchain"
+  version    = "latest"
+  depends_on = [google_project_service.secretmanager]
+}
+
+data "google_secret_manager_secret_version" "cert_key" {
+  for_each   = toset(var.full_nodes)
+  secret     = "${local.prefix}-${each.key}-cert-key"
+  version    = "latest"
+  depends_on = [google_project_service.secretmanager]
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -13,12 +13,13 @@ environment = "dev"
 machine_type    = "e2-standard-4"
 prefix          = "canto"
 validator_nodes = ["validator1"]
-full_nodes      = ["full-node1", "full-node2"]
+full_nodes      = ["node1", "node2"]
 ssh_keys = {
   "andre" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXL0+ecc//lAJhiY0YIpKjkHXA7SUv4ouw+29Gps8YYme8fzTn7/gWWO11ALqqqycoJuLn7CBzCRWrUmxn1u2XsEQyaYmfbRKAUktbevHgJtQv2l8OhAmWFhRKvuMA/J5L5jY4FoozC0iQywQWLbC4Vzh7gjwxmqS7PPbamzE6xa45aI4AsxPHN1Ac2tUuuow5ILGC4Vw2bHa/7k5dnwLTGFAIJIXAn4nullC5y4hLQMJPK7NzW+77PKXzEJEye26c98rEbqdzNBnxjz+TH0B6IMZ6GtnmjArCMJPbWfitjBc8Qf/q5X8akoPQqZpkqu/ZB/MXrhfxz400PjZ0yYK710bL+wC0oeEgjlFxfuBPCICSiJqTRVr6O4tkDG3axnqPWKQjUlXkMkQkMjjZy0oZmF1/mffdODuJ6ALicREjKAcS+yOzVcJP9ZqMFHwLhaGLYjCGy//w6q/R2uVm51qEOiWP824ESIFzOQly6Udh1Jeue5JRCaAuZv+6wP4RNO8="
 }
 create_firewall_rule = true
-vm_tags              = ["tendermint-p2p"]
+node_domain_suffix   = ".canto.ansybl.io"
+create_reverse_proxy = true
 
 # https://docs.canto.io/evm-development/quickstart-guide
 environment_to_chain_id = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,10 +54,16 @@ variable "create_firewall_rule" {
   default     = false
 }
 
-variable "vm_tags" {
-  description = "Additional network tags for the instances."
+variable "nodes_vm_tags" {
+  description = "Additional network tags for the nodes instances."
   type        = list(string)
-  default     = []
+  default     = ["tendermint-p2p", "tendermint-api", "tendermint-rpc"]
+}
+
+variable "validators_vm_tags" {
+  description = "Additional network tags for the validators instances."
+  type        = list(string)
+  default     = ["tendermint-p2p"]
 }
 
 variable "full_nodes" {
@@ -81,6 +87,35 @@ variable "environment_to_chain_id" {
   type = map(string)
 }
 
+variable "tendermint_p2p_port" {
+  description = "Port for interacting with the p2p Tendermint network."
+  type        = number
+  default     = 26656
+}
+
+variable "tendermint_rpc_port" {
+  description = "Port Tendermint RPC will listen on."
+  type        = number
+  default     = 26657
+}
+
+variable "tendermint_api_port" {
+  description = "Port for interacting with the REST API."
+  type        = number
+  default     = 1317
+}
+
+variable "node_domain_suffix" {
+  description = "Used for the certificate, node domain will be <node>.<node_domain_suffix>"
+  type        = string
+  default     = ""
+}
+
+variable "create_reverse_proxy" {
+  description = "Setup a reverse proxy in front of the node (useful for getting the REST API over SSL)."
+  type        = bool
+  default     = false
+}
 
 locals {
   environment = terraform.workspace


### PR DESCRIPTION
Introduce reverse proxy to handle node REST API requests over SSL. Enable this resource using the `create_reverse_proxy` boolean.

Deploying the reverse proxy requires having the certificates and their private key ready in the secret secret manager.

The reverse proxy is currently deployed using a compute instance while ideally it should use a cloud run service. That can be addressed later.