### PR TITLE
:bricks: Expose the EVM RPC service (port 8545)

### DIFF
--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -43,3 +43,17 @@ resource "google_compute_firewall" "allow_tag_tendermint_api" {
     ports    = [var.tendermint_api_port]
   }
 }
+
+resource "google_compute_firewall" "allow_tag_tendermint_evm_rpc" {
+  count       = var.create_firewall_rule ? 1 : 0
+  name        = "${local.prefix}${local.instance_name}-ingress-tag-evm-rpc"
+  description = "Ingress to allow Tendermint EVM RPC ports to machines with the 'tendermint-evm-rpc' tag"
+  network = var.network_name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["tendermint-evm-rpc"]
+
+  allow {
+    protocol = "tcp"
+    ports    = [var.tendermint_evm_rpc_port]
+  }
+}

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -38,6 +38,12 @@ variable "tendermint_api_port" {
   default     = 1317
 }
 
+variable "tendermint_evm_rpc_port" {
+  description = "Port for interacting with the EVM RPC server."
+  type        = number
+  default     = 8545
+}
+
 variable "instance_name" {
   description = "The desired name to assign to the deployed instance"
   default = "disk-instance-vm-test"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,7 +57,7 @@ variable "create_firewall_rule" {
 variable "nodes_vm_tags" {
   description = "Additional network tags for the nodes instances."
   type        = list(string)
-  default     = ["tendermint-p2p", "tendermint-api", "tendermint-rpc"]
+  default     = ["tendermint-p2p", "tendermint-api", "tendermint-rpc", "tendermint-evm-rpc"]
 }
 
 variable "validators_vm_tags" {


### PR DESCRIPTION
Enabled by default on non validators full nodes.
This can be consumed by EVM explorer such as blockscout.