### PR TITLE
:bricks: Use the same proxy for the different protocols

### DIFF
--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -6,7 +6,15 @@ server {
     proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header    Host $http_host;
 
-    location / {
-        proxy_pass ${PROXY_PASS_URL};
+    location /api/ {
+        proxy_pass ${PROXY_PASS_API_URL};
+    }
+
+    location /rpc/ {
+        proxy_pass ${PROXY_PASS_RPC_URL};
+    }
+
+    location /evm_rpc/ {
+        proxy_pass ${PROXY_PASS_EVM_RPC_URL};
     }
 }

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -11,8 +11,16 @@ resource "google_cloud_run_service" "nginx_reverse_proxy" {
           container_port = 80
         }
         env {
-          name  = "PROXY_PASS_URL"
-          value = "http://${module.gce_worker_container[each.key].google_compute_instance_ip}:${var.tendermint_api_port}"
+          name  = "PROXY_PASS_API_URL"
+          value = "http://${module.gce_worker_container[each.key].google_compute_instance_ip}:${var.tendermint_api_port}/"
+        }
+        env {
+          name  = "PROXY_PASS_RPC_URL"
+          value = "http://${module.gce_worker_container[each.key].google_compute_instance_ip}:${var.tendermint_rpc_port}/"
+        }
+        env {
+          name  = "PROXY_PASS_EVM_RPC_URL"
+          value = "http://${module.gce_worker_container[each.key].google_compute_instance_ip}:${var.tendermint_evm_rpc_port}/"
         }
       }
     }

--- a/terraform/gce-with-container/main.tf
+++ b/terraform/gce-with-container/main.tf
@@ -50,10 +50,6 @@ resource "google_compute_instance" "this" {
 
   network_interface {
     network = var.network_name
-
-    access_config {
-      nat_ip = google_compute_address.static.address
-    }
   }
 
   metadata = {

--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -1,7 +1,3 @@
-resource "google_compute_address" "static" {
-  name = "${var.prefix}-${local.instance_name}-ipv4-address-${var.environment}"
-}
-
 resource "google_compute_firewall" "allow_tag_tendermint_p2p" {
   count       = var.create_firewall_rule ? 1 : 0
   name        = "${var.prefix}-${local.instance_name}-ingress-tag-p2p-${var.environment}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -56,10 +56,14 @@ module "gce_worker_container" {
     P2P_PORT                = var.tendermint_p2p_port
     RPC_PORT                = var.tendermint_rpc_port
   }
-  instance_name        = each.key
-  network_name         = "default"
-  create_firewall_rule = var.create_firewall_rule
-  vm_tags              = contains(var.validator_nodes, each.key) ? var.validators_vm_tags : var.nodes_vm_tags
+  instance_name           = each.key
+  network_name            = "default"
+  create_firewall_rule    = var.create_firewall_rule
+  tendermint_api_port     = var.tendermint_api_port
+  tendermint_p2p_port     = var.tendermint_p2p_port
+  tendermint_rpc_port     = var.tendermint_rpc_port
+  tendermint_evm_rpc_port = var.tendermint_evm_rpc_port
+  vm_tags                 = contains(var.validator_nodes, each.key) ? var.validators_vm_tags : var.nodes_vm_tags
   # This has the permission to download images from Container Registry
   client_email = var.client_email
   ssh_keys     = var.ssh_keys

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -26,8 +26,8 @@ environment_to_chain_id = {
   mainnet = "canto_7700-1"
 }
 
-trust_height            = 1895000
-trust_hash              = "e03a1b6455da75269576ee3c31ccbf419c2f6408ad68bbb37e07898d4d2d3d77"
+trust_height            = 1987000
+trust_hash              = "FE48B1199C368FBEC11C785830385CCFBF300B7019068939E4A287AFC99065AB"
 persistent_peers        = "16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656,16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656"
 rpc_servers             = "147.182.255.149:26657,147.182.255.149:26657"
 additional_dependencies = "jq tmux vim"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -100,6 +100,12 @@ variable "tendermint_api_port" {
   default     = 1317
 }
 
+variable "tendermint_evm_rpc_port" {
+  description = "Port for interacting with the EVM RPC server."
+  type        = number
+  default     = 8545
+}
+
 variable "node_domain_suffix" {
   description = "Used for the certificate, node domain will be <node>.<node_domain_suffix>"
   type        = string


### PR DESCRIPTION
Have one reverse proxy per node, but use URL prefix to route to the different port/protocols of the node.

Proxy addresses:
- https://canto-validator-nginx-reverse-proxy-node1-testnet-3mid33wd4a-uc.a.run.app/
- https://canto-validator-nginx-reverse-proxy-node2-testnet-3mid33wd4a-uc.a.run.app/

Currently available root routes:
- /api/ -> node:1317
- /rpc/ -> node:26656
- /evm_rpc/ -> node:8445

Update the `trust_height` so the nodes resync as they got destroyed. Ideally this should be automated, probably as part of the `entrypoint.sh`.