### PR TITLE
:sparkles: Automatically fetch the trusted block

### DIFF
--- a/docker/canto/Dockerfile
+++ b/docker/canto/Dockerfile
@@ -28,6 +28,8 @@ ENV CANTOD_HOME=/root/.cantod
 
 RUN apk add --no-cache --update \
     ca-certificates \
+    curl \
+    jq \
     supervisor
 
 COPY --from=buildenv /go/bin/cantod /tmp/

--- a/terraform/gce-with-container/main.tf
+++ b/terraform/gce-with-container/main.tf
@@ -50,6 +50,7 @@ resource "google_compute_instance" "this" {
 
   network_interface {
     network = var.network_name
+    access_config {}
   }
 
   metadata = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,9 +37,8 @@ module "gce_worker_container" {
   prefix          = var.prefix
   environment     = local.environment
   env_variables = {
-    BOOTSTRAP         = "true"
-    STATE_SYNC_ENABLE = "true"
-    # TODO: make it dynamic
+    BOOTSTRAP               = var.bootstrap
+    STATE_SYNC_ENABLE       = var.state_sync_enable
     TRUST_HEIGHT            = var.trust_height
     TRUST_HASH              = var.trust_hash
     MINIMUM_GAS_PRICES      = var.minimum_gas_prices

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -4,8 +4,8 @@ client_email = "995430163323-compute@developer.gserviceaccount.com"
 
 ## Project setup
 project = "dfpl-playground"
-region  = "us-central1"
-zone    = "us-central1-a"
+region  = "us-east5"
+zone    = "us-east5-a"
 
 ## Validator setup
 # gcloud compute machine-types list
@@ -17,7 +17,6 @@ ssh_keys = {
   "andre" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXL0+ecc//lAJhiY0YIpKjkHXA7SUv4ouw+29Gps8YYme8fzTn7/gWWO11ALqqqycoJuLn7CBzCRWrUmxn1u2XsEQyaYmfbRKAUktbevHgJtQv2l8OhAmWFhRKvuMA/J5L5jY4FoozC0iQywQWLbC4Vzh7gjwxmqS7PPbamzE6xa45aI4AsxPHN1Ac2tUuuow5ILGC4Vw2bHa/7k5dnwLTGFAIJIXAn4nullC5y4hLQMJPK7NzW+77PKXzEJEye26c98rEbqdzNBnxjz+TH0B6IMZ6GtnmjArCMJPbWfitjBc8Qf/q5X8akoPQqZpkqu/ZB/MXrhfxz400PjZ0yYK710bL+wC0oeEgjlFxfuBPCICSiJqTRVr6O4tkDG3axnqPWKQjUlXkMkQkMjjZy0oZmF1/mffdODuJ6ALicREjKAcS+yOzVcJP9ZqMFHwLhaGLYjCGy//w6q/R2uVm51qEOiWP824ESIFzOQly6Udh1Jeue5JRCaAuZv+6wP4RNO8="
 }
 create_firewall_rule = true
-node_domain_suffix   = ".canto.ansybl.io"
 create_reverse_proxy = true
 
 # https://docs.canto.io/evm-development/quickstart-guide
@@ -26,8 +25,6 @@ environment_to_chain_id = {
   mainnet = "canto_7700-1"
 }
 
-trust_height            = 1987000
-trust_hash              = "FE48B1199C368FBEC11C785830385CCFBF300B7019068939E4A287AFC99065AB"
 persistent_peers        = "16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656,16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656"
 rpc_servers             = "147.182.255.149:26657,147.182.255.149:26657"
 additional_dependencies = "jq tmux vim"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -106,12 +106,6 @@ variable "tendermint_evm_rpc_port" {
   default     = 8545
 }
 
-variable "node_domain_suffix" {
-  description = "Used for the certificate, node domain will be <node>.<node_domain_suffix>"
-  type        = string
-  default     = ""
-}
-
 variable "create_reverse_proxy" {
   description = "Setup a reverse proxy in front of the node (useful for getting the REST API over SSL)."
   type        = bool
@@ -129,11 +123,15 @@ variable "state_sync_enable" {
 }
 
 variable "trust_height" {
-  type = number
+  description = "Will be retrieved automatically at run time if state_sync_enable=true and trust_height=0"
+  type        = number
+  default     = 0
 }
 
 variable "trust_hash" {
-  type = string
+  description = "Will be retrieved automatically at run time if state_sync_enable=true and trust_height=0"
+  type        = string
+  default     = ""
 }
 
 variable "minimum_gas_prices" {


### PR DESCRIPTION
This is used when doing the initial state sync.
Automatic trust height/hash retrieval is enabled when `state_sync_enable=true` and `trust_height=0`.

Reinstate `network_interface.access_config` so we still have an external network IP even though it's dynamic.

Also temporarily update the region and zone as the VM instance was no longer available, the error was:
```
VM instance is currently unavailable in the us-east4-c zone.
Alternatively, you can try your request again with a different VM
hardware configuration or at a later time. For more information,
see the troubleshooting documentation.
```
