### PR TITLE
:sparkles: Sentry nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,11 @@ devops/terraform/destroy/all: devops/terraform/select/$(WORKSPACE)
 devops/terraform/destroy/%: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy -target=module.gce_worker_container[\"$*\"].google_compute_instance.this -auto-approve
 
-devops/terraform/destroy/nodes: devops/terraform/destroy/node1 devops/terraform/destroy/node2
+devops/terraform/destroy/nodes: devops/terraform/destroy/node1
 
 devops/terraform/destroy/validators: devops/terraform/destroy/validator1
+
+devops/terraform/destroy/sentries: devops/terraform/destroy/sentry1 devops/terraform/destroy/sentry2
 
 devops/terraform/destroy/proxies: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy -target=google_compute_instance.reverse_proxy -auto-approve
@@ -73,8 +75,14 @@ devops/terraform/destroy/serverless_neg: devops/terraform/select/$(WORKSPACE)
 devops/terraform/redeploy/nodes: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/nodes
 	make devops/terraform/apply
 
-# redeploy the nodes & validators VM
-devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validators devops/terraform/destroy/nodes
+devops/terraform/redeploy/sentries: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/sentries
+	make devops/terraform/apply
+
+devops/terraform/redeploy/validators: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validators
+	make devops/terraform/apply
+
+# redeploy the nodes, sentries and validators VM
+devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validators devops/terraform/destroy/nodes devops/terraform/destroy/sentries
 	make devops/terraform/apply
 
 devops/terraform/output: devops/terraform/select/$(WORKSPACE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canto Validator Infra
 
-Automates Canto validador deployment.
+Automates Canto validadors, full nodes and sentry nodes deployment.
 
 - <https://canto-testnet.ansybl.io/rpc/status>
 

--- a/docker/canto/scripts/entrypoint.sh
+++ b/docker/canto/scripts/entrypoint.sh
@@ -15,7 +15,7 @@ write_app_toml() {
     envsubst < "$CANTOD_HOME/config/app.template.toml" > app.toml
 }
 
-import_keys() {
+import_validator_keys() {
     # non validator would not have these variables set
     if [[ -z "$PRIV_VALIDATOR_KEY" ]]; then
         return
@@ -29,6 +29,14 @@ $PASSPHRASE
 EOF
     rm $KEYFILE_PATH
     echo -e $PRIV_VALIDATOR_KEY > $CANTOD_HOME/${PRIV_VALIDATOR_KEY_FILE:-config/priv_validator_key.json}
+}
+
+# importing the node_key.json to have a deterministic node ID
+import_node_key() {
+    if [[ -z "$NODE_KEY" ]]; then
+        return
+    fi
+    echo -e $NODE_KEY > $CANTOD_HOME/${NODE_KEY_FILE:-config/node_key.json}
 }
 
 # retrieve and set trust height/height automatically if STATE_SYNC_ENABLE=true and TRUST_HEIGHT=0
@@ -120,7 +128,8 @@ add_system_dependencies() {
 initialize "$CANTOD_HOME" cantod
 set_trusted_block
 update_config_files "$CANTOD_HOME/config"
-import_keys
+import_validator_keys
+import_node_key
 add_system_dependencies $ADDITIONAL_DEPENDENCIES
 cd "$CANTOD_HOME"
 exec supervisord --nodaemon --configuration /etc/supervisord.conf

--- a/terraform/gce-with-container/main.tf
+++ b/terraform/gce-with-container/main.tf
@@ -50,7 +50,10 @@ resource "google_compute_instance" "this" {
 
   network_interface {
     network = var.network_name
-    access_config {}
+    network_ip = var.create_static_ip ? google_compute_address.static_internal.address : null
+    access_config {
+      nat_ip = var.create_static_ip ? google_compute_address.static.address : null
+    }
   }
 
   metadata = {

--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -53,3 +53,12 @@ resource "google_compute_firewall" "allow_tag_tendermint_evm_rpc" {
     ports    = [var.tendermint_evm_rpc_port]
   }
 }
+
+resource "google_compute_address" "static" {
+  name = "${var.prefix}-${local.instance_name}-address-${var.environment}"
+}
+
+resource "google_compute_address" "static_internal" {
+  name = "${var.prefix}-${local.instance_name}-internal-address-${var.environment}"
+  address_type = "INTERNAL"
+}

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -47,6 +47,12 @@ variable "tendermint_evm_rpc_port" {
   default     = 8545
 }
 
+variable "create_static_ip" {
+  description = "Create a static IP"
+  type        = bool
+  default     = false
+}
+
 variable "instance_name" {
   description = "The desired name to assign to the deployed instance"
   default = "disk-instance-vm-test"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,11 +31,12 @@ resource "google_storage_bucket" "default" {
 }
 
 resource "google_project_service" "cloud_run_api" {
-  service = "run.googleapis.com"
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
 }
 
 module "gce_worker_container" {
-  for_each        = toset(local.all_nodes)
+  for_each        = { for node in local.all_nodes_with_types : node.slug => node }
   source          = "./gce-with-container"
   image           = "gcr.io/${var.project}/${local.canto_image_name}:${var.image_tag}"
   privileged_mode = true
@@ -44,33 +45,43 @@ module "gce_worker_container" {
   prefix          = var.prefix
   environment     = local.environment
   env_variables = {
-    MONIKER                 = each.key
+    MONIKER                 = each.value.slug
     BOOTSTRAP               = var.bootstrap
     STATE_SYNC_ENABLE       = var.state_sync_enable
     TRUST_HEIGHT            = var.trust_height
     TRUST_HASH              = var.trust_hash
     MINIMUM_GAS_PRICES      = var.minimum_gas_prices
     CHAIN_ID                = local.chain_id
-    PERSISTENT_PEERS        = var.persistent_peers
+    PERSISTENT_PEERS        = join(",", local.persistent_peers_by_type[each.value.type])
+    PRIVATE_PEER_IDS        = join(",", var.private_peer_ids)
     RPC_SERVERS             = var.rpc_servers
     ADDITIONAL_DEPENDENCIES = var.additional_dependencies
-    TENDERMINT_KEYFILE      = contains(var.validator_nodes, each.key) ? replace(data.google_secret_manager_secret_version.tendermint_keyfile[each.key].secret_data, "\n", "\\n") : ""
-    PASSPHRASE              = contains(var.validator_nodes, each.key) ? data.google_secret_manager_secret_version.passphrase[each.key].secret_data : ""
-    PRIV_VALIDATOR_KEY      = contains(var.validator_nodes, each.key) ? replace(data.google_secret_manager_secret_version.priv_validator_key[each.key].secret_data, "\n", "\\n") : ""
-    API                     = contains(var.full_nodes, each.key) ? "true" : "false"
-    UNSAFE_CORS             = contains(var.full_nodes, each.key) ? "true" : "false"
-    API_PORT                = var.tendermint_api_port
-    P2P_PORT                = var.tendermint_p2p_port
-    RPC_PORT                = var.tendermint_rpc_port
+    TENDERMINT_KEYFILE      = each.value.type == "validator" ? replace(data.google_secret_manager_secret_version.tendermint_keyfile[each.key].secret_data, "\n", "\\n") : ""
+    PASSPHRASE              = each.value.type == "validator" ? data.google_secret_manager_secret_version.passphrase[each.key].secret_data : ""
+    PRIV_VALIDATOR_KEY      = each.value.type == "validator" ? replace(data.google_secret_manager_secret_version.priv_validator_key[each.key].secret_data, "\n", "\\n") : ""
+    NODE_KEY                = contains(["sentry", "validator"], each.value.type) ? replace(data.google_secret_manager_secret_version.node_key[each.key].secret_data, "\n", "\\n") : ""
+    # Turn this off for the nodes that are on a LAN IP.
+    # By default, only nodes with a routable address will be considered for connection.
+    # If this setting is turned off, non-routable IP addresses, like addresses in a private network, can be added to the address book.
+    ADDR_BOOK_STRICT = contains(["sentry", "validator"], each.value.type) ? false : true
+    # disable the peer exchange for validators
+    PEX         = each.value.type != "validator"
+    API         = each.value.type == "full" ? "true" : "false"
+    UNSAFE_CORS = each.value.type == "full" ? "true" : "false"
+    API_PORT    = var.tendermint_api_port
+    P2P_PORT    = var.tendermint_p2p_port
+    RPC_PORT    = var.tendermint_rpc_port
   }
-  instance_name           = each.key
-  network_name            = "default"
+  instance_name = each.value.slug
+  network_name  = "default"
+  # sentry nodes should have a deterministic IP so validators don't have to update it every now and then
+  create_static_ip        = each.value.type == "sentry"
   create_firewall_rule    = var.create_firewall_rule
   tendermint_api_port     = var.tendermint_api_port
   tendermint_p2p_port     = var.tendermint_p2p_port
   tendermint_rpc_port     = var.tendermint_rpc_port
   tendermint_evm_rpc_port = var.tendermint_evm_rpc_port
-  vm_tags                 = contains(var.validator_nodes, each.key) ? var.validators_vm_tags : var.nodes_vm_tags
+  vm_tags                 = each.value.type == "validator" ? var.validators_vm_tags : var.nodes_vm_tags
   # This has the permission to download images from Container Registry
   client_email = var.client_email
   ssh_keys     = var.ssh_keys

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -23,3 +23,13 @@ data "google_secret_manager_secret_version" "priv_validator_key" {
   version    = "latest"
   depends_on = [google_project_service.secretmanager]
 }
+
+# Redeploying the same key to guarantee the same node ID.
+# This is useful to have a deterministic persistent_peers (`node-id@sentry-ip:port`) setting.
+# This is also useful to know the validator ID to fill the `private_peer_ids` setting.
+data "google_secret_manager_secret_version" "node_key" {
+  for_each   = toset(concat(var.validator_nodes, var.sentry_nodes))
+  secret     = "${var.prefix}-${each.key}-node-key-${local.environment}"
+  version    = "latest"
+  depends_on = [google_project_service.secretmanager]
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -13,6 +13,7 @@ machine_type    = "e2-standard-4"
 prefix          = "canto-validator"
 validator_nodes = ["validator1"]
 full_nodes      = ["node1"]
+sentry_nodes    = ["sentry1", "sentry2"]
 ssh_keys = {
   "andre" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXL0+ecc//lAJhiY0YIpKjkHXA7SUv4ouw+29Gps8YYme8fzTn7/gWWO11ALqqqycoJuLn7CBzCRWrUmxn1u2XsEQyaYmfbRKAUktbevHgJtQv2l8OhAmWFhRKvuMA/J5L5jY4FoozC0iQywQWLbC4Vzh7gjwxmqS7PPbamzE6xa45aI4AsxPHN1Ac2tUuuow5ILGC4Vw2bHa/7k5dnwLTGFAIJIXAn4nullC5y4hLQMJPK7NzW+77PKXzEJEye26c98rEbqdzNBnxjz+TH0B6IMZ6GtnmjArCMJPbWfitjBc8Qf/q5X8akoPQqZpkqu/ZB/MXrhfxz400PjZ0yYK710bL+wC0oeEgjlFxfuBPCICSiJqTRVr6O4tkDG3axnqPWKQjUlXkMkQkMjjZy0oZmF1/mffdODuJ6ALicREjKAcS+yOzVcJP9ZqMFHwLhaGLYjCGy//w6q/R2uVm51qEOiWP824ESIFzOQly6Udh1Jeue5JRCaAuZv+6wP4RNO8="
 }
@@ -32,6 +33,25 @@ node_to_domain_map = {
   node1 = "canto-testnet"
 }
 
-persistent_peers        = "16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656,16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656"
+persistent_peers = [
+  "16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656",
+  "16ca056442ffcfe509cee9be37817370599dcee1@147.182.255.149:26656",
+]
+# The validators should only be connected to the sentry nodes.
+# We're using the VPC internal IPs so we're not firewalled.
+# The validator ports are only open for instances in the same VPC.
+validator_persistent_peers = [
+  # sentry1
+  "4c24b20961a7abb1f1bc7d7ff8acece6584b4fae@10.202.0.27:26656",
+  # sentry2
+  "bf99d6404680047a65d73c37e98bbfcbf476181f@10.202.0.30:26656",
+]
+private_peer_ids = [
+  # validator1
+  "f542db1ecb08243d613c705c43e95521dfee77b9",
+]
+# Overriding the default to remove p2p since we're going through Sentry nodes
+# which will connect via the VPC internal IPs which isn't firewalled.
+validators_vm_tags      = []
 rpc_servers             = "147.182.255.149:26657,147.182.255.149:26657"
 additional_dependencies = "jq tmux vim"


### PR DESCRIPTION
Setup two sentry nodes following this guide:
https://forum.cosmos.network/t/sentry-node-architecture-overview/454

The validator node ports are now all firewalled/closed on the external IP except for SSH. The sentry nodes will communicate with the validators using the validator internal/private VPC IP.
We're now importing the `node_key.json` on both validators and sentries so that the node ID is known upfront.
This is needed the validator `persistent_peers` setting and the sentry `private_peer_ids`.

Note the validators still have a public IP at the moment for convenience.