### PR TITLE
:money_with_wings: Optimize VM cost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ devops/terraform/list:
 	terraform -chdir=terraform workspace list
 
 devops/terraform/fmt:
-	terraform -chdir=terraform fmt
+	terraform -chdir=terraform fmt -recursive
 
 devops/terraform/init:
 	terraform -chdir=terraform init -reconfigure

--- a/terraform/gce-with-container/main.tf
+++ b/terraform/gce-with-container/main.tf
@@ -3,7 +3,7 @@ locals {
   instance_name = format("%s-%s", var.instance_name, substr(md5(module.gce-container.container.image), 0, 8))
 
   env_variables = [for var_name, var_value in var.env_variables : {
-    name = var_name
+    name  = var_name
     value = var_value
   }]
 }
@@ -13,13 +13,13 @@ locals {
 
 module "gce-container" {
   # https://github.com/terraform-google-modules/terraform-google-container-vm
-  source = "terraform-google-modules/container-vm/google"
+  source  = "terraform-google-modules/container-vm/google"
   version = "3.1.0"
 
   container = {
-    image = var.image
+    image   = var.image
     command = var.custom_command
-    env = local.env_variables
+    env     = local.env_variables
     securityContext = {
       privileged : var.privileged_mode
     }
@@ -33,7 +33,7 @@ module "gce-container" {
 ##### COMPUTE ENGINE
 
 resource "google_compute_instance" "this" {
-  name = "${var.prefix}-${local.instance_name}-${var.environment}"
+  name         = "${var.prefix}-${local.instance_name}-${var.environment}"
   machine_type = var.machine_type
   # If true, allows Terraform to stop the instance to update its properties.
   allow_stopping_for_update = true
@@ -42,13 +42,13 @@ resource "google_compute_instance" "this" {
   boot_disk {
     initialize_params {
       image = module.gce-container.source_image
-      size = 100
-      type = "pd-balanced"
+      size  = 100
+      type  = "pd-balanced"
     }
   }
 
   network_interface {
-    network = var.network_name
+    network    = var.network_name
     network_ip = var.create_static_ip ? google_compute_address.static_internal.address : null
     access_config {
       nat_ip = var.create_static_ip ? google_compute_address.static.address : null
@@ -57,7 +57,7 @@ resource "google_compute_instance" "this" {
 
   metadata = {
     gce-container-declaration = module.gce-container.metadata_value
-    ssh-keys = join("\n", [for user, key in var.ssh_keys : "${user}:${key}"])
+    ssh-keys                  = join("\n", [for user, key in var.ssh_keys : "${user}:${key}"])
   }
 
   labels = {

--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -1,8 +1,8 @@
 resource "google_compute_firewall" "allow_tag_tendermint_p2p" {
-  count       = var.create_firewall_rule ? 1 : 0
-  name        = "${var.prefix}-${local.instance_name}-ingress-tag-p2p-${var.environment}"
-  description = "Ingress to allow Tendermint P2P ports to machines with the 'tendermint-p2p' tag"
-  network = var.network_name
+  count         = var.create_firewall_rule ? 1 : 0
+  name          = "${var.prefix}-${local.instance_name}-ingress-tag-p2p-${var.environment}"
+  description   = "Ingress to allow Tendermint P2P ports to machines with the 'tendermint-p2p' tag"
+  network       = var.network_name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["tendermint-p2p"]
 
@@ -13,10 +13,10 @@ resource "google_compute_firewall" "allow_tag_tendermint_p2p" {
 }
 
 resource "google_compute_firewall" "allow_tag_tendermint_rpc" {
-  count       = var.create_firewall_rule ? 1 : 0
-  name        = "${var.prefix}-${local.instance_name}-ingress-tag-rpc-${var.environment}"
-  description = "Ingress to allow Tendermint RPC ports to machines with the 'tendermint-rpc' tag"
-  network = var.network_name
+  count         = var.create_firewall_rule ? 1 : 0
+  name          = "${var.prefix}-${local.instance_name}-ingress-tag-rpc-${var.environment}"
+  description   = "Ingress to allow Tendermint RPC ports to machines with the 'tendermint-rpc' tag"
+  network       = var.network_name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["tendermint-rpc"]
 
@@ -27,10 +27,10 @@ resource "google_compute_firewall" "allow_tag_tendermint_rpc" {
 }
 
 resource "google_compute_firewall" "allow_tag_tendermint_api" {
-  count       = var.create_firewall_rule ? 1 : 0
-  name        = "${var.prefix}-${local.instance_name}-ingress-tag-api-${var.environment}"
-  description = "Ingress to allow Tendermint API ports to machines with the 'tendermint-api' tag"
-  network = var.network_name
+  count         = var.create_firewall_rule ? 1 : 0
+  name          = "${var.prefix}-${local.instance_name}-ingress-tag-api-${var.environment}"
+  description   = "Ingress to allow Tendermint API ports to machines with the 'tendermint-api' tag"
+  network       = var.network_name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["tendermint-api"]
 
@@ -41,10 +41,10 @@ resource "google_compute_firewall" "allow_tag_tendermint_api" {
 }
 
 resource "google_compute_firewall" "allow_tag_tendermint_evm_rpc" {
-  count       = var.create_firewall_rule ? 1 : 0
-  name        = "${var.prefix}-${local.instance_name}-ingress-tag-evm-rpc-${var.environment}"
-  description = "Ingress to allow Tendermint EVM RPC ports to machines with the 'tendermint-evm-rpc' tag"
-  network = var.network_name
+  count         = var.create_firewall_rule ? 1 : 0
+  name          = "${var.prefix}-${local.instance_name}-ingress-tag-evm-rpc-${var.environment}"
+  description   = "Ingress to allow Tendermint EVM RPC ports to machines with the 'tendermint-evm-rpc' tag"
+  network       = var.network_name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["tendermint-evm-rpc"]
 
@@ -59,6 +59,6 @@ resource "google_compute_address" "static" {
 }
 
 resource "google_compute_address" "static_internal" {
-  name = "${var.prefix}-${local.instance_name}-internal-address-${var.environment}"
+  name         = "${var.prefix}-${local.instance_name}-internal-address-${var.environment}"
   address_type = "INTERNAL"
 }

--- a/terraform/gce-with-container/outputs.tf
+++ b/terraform/gce-with-container/outputs.tf
@@ -5,7 +5,7 @@ output "google_compute_instance_ip" {
 
 output "google_compute_instance_name_ip_map" {
   description = "The name and the IP of the compute instance"
-  value       = {
-    (google_compute_instance.this.name): google_compute_instance.this.network_interface.0.access_config.0.nat_ip
+  value = {
+    (google_compute_instance.this.name) : google_compute_instance.this.network_interface.0.access_config.0.nat_ip
   }
 }

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -4,7 +4,7 @@ variable "prefix" {
 }
 
 variable "environment" {
-  type        = string
+  type = string
 }
 
 variable "network_name" {
@@ -13,7 +13,7 @@ variable "network_name" {
 
 variable "vm_tags" {
   description = "Additional network tags for the instances."
-  type = list(string)
+  type        = list(string)
   default     = []
 }
 
@@ -55,7 +55,7 @@ variable "create_static_ip" {
 
 variable "instance_name" {
   description = "The desired name to assign to the deployed instance"
-  default = "disk-instance-vm-test"
+  default     = "disk-instance-vm-test"
 }
 
 variable "image" {
@@ -63,12 +63,12 @@ variable "image" {
 }
 
 variable "env_variables" {
-  type = map(string)
+  type    = map(string)
   default = null
 }
 
 variable "privileged_mode" {
-  type = bool
+  type    = bool
   default = false
 }
 
@@ -79,7 +79,7 @@ variable "privileged_mode" {
 # e2-small / 2 / 2.00
 # g1-small / 1 / 1.70
 variable "machine_type" {
-  type = string
+  type    = string
   default = "f1-micro"
 }
 
@@ -88,23 +88,23 @@ variable "ssh_keys" {
 }
 
 variable "activate_tty" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "custom_command" {
-  type = list(string)
+  type    = list(string)
   default = null
 }
 
 variable "additional_metadata" {
-  type = map(string)
+  type        = map(string)
   description = "Additional metadata to attach to the instance"
-  default = null
+  default     = null
 }
 
 variable "client_email" {
   description = "Service account email address"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,7 +41,7 @@ module "gce_worker_container" {
   image           = "gcr.io/${var.project}/${local.canto_image_name}:${var.image_tag}"
   privileged_mode = true
   activate_tty    = true
-  machine_type    = var.machine_type
+  machine_type    = var.machine_types[each.value.type]
   prefix          = var.prefix
   environment     = local.environment
   env_variables = {
@@ -54,7 +54,7 @@ module "gce_worker_container" {
     CHAIN_ID                = local.chain_id
     PERSISTENT_PEERS        = join(",", local.persistent_peers_by_type[each.value.type])
     PRIVATE_PEER_IDS        = join(",", var.private_peer_ids)
-    RPC_SERVERS             = var.rpc_servers
+    RPC_SERVERS             = join(",", var.rpc_servers)
     ADDITIONAL_DEPENDENCIES = var.additional_dependencies
     TENDERMINT_KEYFILE      = each.value.type == "validator" ? replace(data.google_secret_manager_secret_version.tendermint_keyfile[each.key].secret_data, "\n", "\\n") : ""
     PASSPHRASE              = each.value.type == "validator" ? data.google_secret_manager_secret_version.passphrase[each.key].secret_data : ""
@@ -66,8 +66,8 @@ module "gce_worker_container" {
     ADDR_BOOK_STRICT = contains(["sentry", "validator"], each.value.type) ? false : true
     # disable the peer exchange for validators
     PEX         = each.value.type != "validator"
-    API         = each.value.type == "full" ? "true" : "false"
-    UNSAFE_CORS = each.value.type == "full" ? "true" : "false"
+    API         = each.value.type == "full"
+    UNSAFE_CORS = each.value.type == "full"
     API_PORT    = var.tendermint_api_port
     P2P_PORT    = var.tendermint_p2p_port
     RPC_PORT    = var.tendermint_rpc_port

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -9,7 +9,11 @@ zone    = "us-east5-a"
 
 ## Validator setup
 # gcloud compute machine-types list
-machine_type    = "e2-standard-4"
+machine_types = {
+  validator = "e2-standard-2"
+  full      = "e2-standard-2"
+  sentry    = "e2-standard-2"
+}
 prefix          = "canto-validator"
 validator_nodes = ["validator1"]
 full_nodes      = ["node1"]
@@ -52,6 +56,10 @@ private_peer_ids = [
 ]
 # Overriding the default to remove p2p since we're going through Sentry nodes
 # which will connect via the VPC internal IPs which isn't firewalled.
-validators_vm_tags      = []
-rpc_servers             = "147.182.255.149:26657,147.182.255.149:26657"
+validators_vm_tags = []
+# TODO: also use our public RPC servers, not only the Plex one
+rpc_servers = [
+  "147.182.255.149:26657",
+  "147.182.255.149:26657",
+]
 additional_dependencies = "jq tmux vim"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,8 +24,9 @@ variable "zone" {
 
 ## validator variables
 
-variable "machine_type" {
-  type = string
+variable "machine_types" {
+  description = "Per node type machine type"
+  type        = map(string)
 }
 
 variable "prefix" {
@@ -170,7 +171,7 @@ variable "private_peer_ids" {
 }
 
 variable "rpc_servers" {
-  type = string
+  type = list(string)
 }
 
 variable "additional_dependencies" {


### PR DESCRIPTION
Reduce 1 validator node, 1 RPC node and 2 Sentry nodes VM size to save a total of $200/month.
- from e2-standard-4 (4 cores, 16G of RAM) at ~$100/month
- to e2-standard-2 (2 cores, 8G of RAM) at ~$50/month

refs:
- https://www.economize.cloud/resources/gcp/pricing/e2/e2-standard-4
- https://www.economize.cloud/resources/gcp/pricing/e2/e2-standard-2

Also format code recursively