### PR TITLE
:chart_with_upwards_trend: Enable/expose Tendermint metrics

### DIFF
--- a/docker/canto/config/config.template.toml
+++ b/docker/canto/config/config.template.toml
@@ -416,7 +416,7 @@ indexer = "${INDEXER_SELECTION:-kv}"
 prometheus = ${PROMETHEUS:-false}
 
 # Address to listen for Prometheus collector(s) connections
-prometheus_listen_addr = ":26660"
+prometheus_listen_addr = ":${PROMETHEUS_PORT:-26660}"
 
 # Maximum number of simultaneous connections.
 # If you want to accept a larger number than the default, make sure

--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -54,6 +54,20 @@ resource "google_compute_firewall" "allow_tag_tendermint_evm_rpc" {
   }
 }
 
+resource "google_compute_firewall" "allow_tag_tendermint_prometheus" {
+  count         = var.create_firewall_rule ? 1 : 0
+  name          = "${var.prefix}-${local.instance_name}-ingress-tag-prom-${var.environment}"
+  description   = "Ingress to allow Tendermint Prometheus port to machines with the 'tendermint-prometheus' tag"
+  network       = var.network_name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["tendermint-prometheus"]
+
+  allow {
+    protocol = "tcp"
+    ports    = [var.tendermint_prometheus_port]
+  }
+}
+
 resource "google_compute_address" "static" {
   name = "${var.prefix}-${local.instance_name}-address-${var.environment}"
 }

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -59,6 +59,12 @@ variable "tendermint_evm_rpc_port" {
   default     = 8545
 }
 
+variable "tendermint_prometheus_port" {
+  description = "Port for exposing the Prometheus exporter"
+  type        = number
+  default     = 26660
+}
+
 variable "create_static_ip" {
   description = "Create a static IP"
   type        = bool

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,6 +60,7 @@ module "gce_worker_container" {
     PASSPHRASE              = each.value.type == "validator" ? data.google_secret_manager_secret_version.passphrase[each.key].secret_data : ""
     PRIV_VALIDATOR_KEY      = each.value.type == "validator" ? replace(data.google_secret_manager_secret_version.priv_validator_key[each.key].secret_data, "\n", "\\n") : ""
     NODE_KEY                = contains(["sentry", "validator"], each.value.type) ? replace(data.google_secret_manager_secret_version.node_key[each.key].secret_data, "\n", "\\n") : ""
+    PROMETHEUS              = var.enable_tendermint_prometheus
     # Turn this off for the nodes that are on a LAN IP.
     # By default, only nodes with a routable address will be considered for connection.
     # If this setting is turned off, non-routable IP addresses, like addresses in a private network, can be added to the address book.
@@ -74,8 +75,9 @@ module "gce_worker_container" {
   }
   instance_name = each.value.slug
   network_name  = "default"
-  # sentry nodes should have a deterministic IP so validators don't have to update it every now and then
-  create_static_ip        = each.value.type == "sentry"
+  # we often use the internal static IP for unfirewalled communications within the VPC e.g.
+  # validators to sentry p2p connection, exposed prometheus metrics...
+  create_static_ip        = true
   create_firewall_rule    = var.create_firewall_rule
   tendermint_api_port     = var.tendermint_api_port
   tendermint_p2p_port     = var.tendermint_p2p_port

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -21,9 +21,10 @@ sentry_nodes    = ["sentry1", "sentry2"]
 ssh_keys = {
   "andre" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXL0+ecc//lAJhiY0YIpKjkHXA7SUv4ouw+29Gps8YYme8fzTn7/gWWO11ALqqqycoJuLn7CBzCRWrUmxn1u2XsEQyaYmfbRKAUktbevHgJtQv2l8OhAmWFhRKvuMA/J5L5jY4FoozC0iQywQWLbC4Vzh7gjwxmqS7PPbamzE6xa45aI4AsxPHN1Ac2tUuuow5ILGC4Vw2bHa/7k5dnwLTGFAIJIXAn4nullC5y4hLQMJPK7NzW+77PKXzEJEye26c98rEbqdzNBnxjz+TH0B6IMZ6GtnmjArCMJPbWfitjBc8Qf/q5X8akoPQqZpkqu/ZB/MXrhfxz400PjZ0yYK710bL+wC0oeEgjlFxfuBPCICSiJqTRVr6O4tkDG3axnqPWKQjUlXkMkQkMjjZy0oZmF1/mffdODuJ6ALicREjKAcS+yOzVcJP9ZqMFHwLhaGLYjCGy//w6q/R2uVm51qEOiWP824ESIFzOQly6Udh1Jeue5JRCaAuZv+6wP4RNO8="
 }
-create_firewall_rule = true
-create_reverse_proxy = true
-create_load_balancer = true
+create_firewall_rule         = true
+create_reverse_proxy         = true
+create_load_balancer         = true
+enable_tendermint_prometheus = true
 
 domain_suffix = "ansybl.io"
 
@@ -56,6 +57,7 @@ private_peer_ids = [
 ]
 # Overriding the default to remove p2p since we're going through Sentry nodes
 # which will connect via the VPC internal IPs which isn't firewalled.
+# Same thing for Prometheus.
 validators_vm_tags = []
 # TODO: also use our public RPC servers, not only the Plex one
 rpc_servers = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -53,13 +53,13 @@ variable "create_firewall_rule" {
 variable "nodes_vm_tags" {
   description = "Additional network tags for the nodes instances."
   type        = list(string)
-  default     = ["tendermint-p2p", "tendermint-api", "tendermint-rpc", "tendermint-evm-rpc"]
+  default     = ["tendermint-p2p", "tendermint-api", "tendermint-rpc", "tendermint-evm-rpc", "tendermint-prometheus"]
 }
 
 variable "validators_vm_tags" {
   description = "Additional network tags for the validators instances."
   type        = list(string)
-  default     = ["tendermint-p2p"]
+  default     = ["tendermint-p2p", "tendermint-prometheus"]
 }
 
 variable "full_nodes" {
@@ -193,6 +193,12 @@ variable "node_to_domain_map" {
   description = "Used to map the domain that should be associated to the full node"
   type        = map(string)
   default     = {}
+}
+
+variable "enable_tendermint_prometheus" {
+  description = "Enable Prometheus exporter for Tendermint."
+  type        = bool
+  default     = false
 }
 
 locals {


### PR DESCRIPTION
Exposed for all type of nodes.
The service is only exposed from within the VPC, hence consuming the metrics should be done using the internal IP.
The service can be exposed to the outside world using the `tendermint-prometheus` vm tag.