### PR TITLE
:sparkles: Enable validator and full node app metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,36 +83,23 @@ devops/terraform/apply: devops/terraform/select/$(WORKSPACE)
 devops/terraform/destroy/all: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy
 
-# only destroy the VM
-devops/terraform/destroy/%: devops/terraform/select/$(WORKSPACE)
-	terraform -chdir=terraform destroy -target=module.gce_worker_container[\"$*\"].google_compute_instance.this -auto-approve
-
-devops/terraform/destroy/nodes: devops/terraform/destroy/node1
-
-devops/terraform/destroy/validators: devops/terraform/destroy/validator1
-
-devops/terraform/destroy/sentries: devops/terraform/destroy/sentry1 devops/terraform/destroy/sentry2
-
-devops/terraform/destroy/proxies: devops/terraform/select/$(WORKSPACE)
-	terraform -chdir=terraform destroy -target=google_compute_instance.reverse_proxy -auto-approve
+# only redeploy the VM
+devops/terraform/redeploy/vm/%: devops/terraform/select/$(WORKSPACE)
+	terraform -chdir=terraform apply -replace=module.gce_worker_container[\"$*\"].google_compute_instance.this -auto-approve
 
 # https://github.com/terraform-google-modules/terraform-google-lb-http/blob/v6.3.0/docs/upgrading-v2.0.0-v3.0.0.md#dealing-with-dependencies
 devops/terraform/destroy/serverless_neg: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy \
 	-target=google_compute_region_network_endpoint_group.serverless_neg -auto-approve
 
-devops/terraform/redeploy/nodes: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/nodes
-	make devops/terraform/apply
+devops/terraform/redeploy/nodes: devops/terraform/redeploy/vm/node1
 
-devops/terraform/redeploy/sentries: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/sentries
-	make devops/terraform/apply
+devops/terraform/redeploy/sentries: devops/terraform/redeploy/vm/sentry1 devops/terraform/redeploy/vm/sentry2
 
-devops/terraform/redeploy/validators: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validators
-	make devops/terraform/apply
+devops/terraform/redeploy/validators: devops/terraform/redeploy/vm/validator1
 
 # redeploy the nodes, sentries and validators VM
-devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/destroy/validators devops/terraform/destroy/nodes devops/terraform/destroy/sentries
-	make devops/terraform/apply
+devops/terraform/redeploy/all: devops/terraform/select/$(WORKSPACE) devops/terraform/redeploy/validators devops/terraform/redeploy/nodes devops/terraform/redeploy/sentries
 
 devops/terraform/output: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform output

--- a/docker/canto/config/app.template.toml
+++ b/docker/canto/config/app.template.toml
@@ -76,7 +76,7 @@ service-name = ""
 # Enabled enables the application telemetry functionality. When enabled,
 # an in-memory sink is also enabled by default. Operators may also enabled
 # other sinks such as Prometheus.
-enabled = false
+enabled = ${APP_TELEMETRY:-false}
 
 # Enable prefixing gauge values with hostname.
 enable-hostname = false
@@ -88,7 +88,7 @@ enable-hostname-label = false
 enable-service-label = false
 
 # PrometheusRetentionTime, when positive, enables a Prometheus metrics sink.
-prometheus-retention-time = 0
+prometheus-retention-time = ${APP_PROMETHEUS_RETENTION_TIME:-0}
 
 # GlobalLabels defines a global set of name/value label tuples applied to all
 # metrics emitted using the wrapper functions defined in telemetry package.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,14 +64,19 @@ module "gce_worker_container" {
     # Turn this off for the nodes that are on a LAN IP.
     # By default, only nodes with a routable address will be considered for connection.
     # If this setting is turned off, non-routable IP addresses, like addresses in a private network, can be added to the address book.
-    ADDR_BOOK_STRICT = contains(["sentry", "validator"], each.value.type) ? false : true
+    ADDR_BOOK_STRICT = !contains(["sentry", "validator"], each.value.type)
     # disable the peer exchange for validators
-    PEX         = each.value.type != "validator"
-    API         = each.value.type == "full"
-    UNSAFE_CORS = each.value.type == "full"
-    API_PORT    = var.tendermint_api_port
-    P2P_PORT    = var.tendermint_p2p_port
-    RPC_PORT    = var.tendermint_rpc_port
+    PEX = each.value.type != "validator"
+    # while the validator has the API enabled for metrics, it's only exposed through the VPC
+    # since it doesn't (and shouldn't) contain the `tendermint-api` tag
+    API                           = contains(["full", "validator"], each.value.type)
+    SWAGGER                       = contains(["full", "validator"], each.value.type)
+    APP_TELEMETRY                 = contains(["full", "validator"], each.value.type)
+    APP_PROMETHEUS_RETENTION_TIME = contains(["full", "validator"], each.value.type) ? 60 : 0
+    UNSAFE_CORS                   = each.value.type == "full"
+    API_PORT                      = var.tendermint_api_port
+    P2P_PORT                      = var.tendermint_p2p_port
+    RPC_PORT                      = var.tendermint_rpc_port
   }
   instance_name = each.value.slug
   network_name  = "default"


### PR DESCRIPTION
Note that this metric could be redundant with the Tendermint one. Also improve the redeployment Makefile targets by using the `replace` flag